### PR TITLE
Fix re-render error with profile image

### DIFF
--- a/code/web/src/modules/user/ProfilePicture.js
+++ b/code/web/src/modules/user/ProfilePicture.js
@@ -6,7 +6,7 @@ import { upload, messageShow, messageHide } from '../common/api/actions'
 import { renderIf } from '../../setup/helpers'
 import { routeImage } from '../../setup/routes'
 import { APP_URL, APP_URL_API } from '../../setup/config/env'
-import { updateUser } from './api/actions'
+import { updateUser, getUser } from './api/actions'
 
 class ProfilePicture extends Component {
   constructor() {
@@ -58,6 +58,7 @@ class ProfilePicture extends Component {
 
     saveChanges = () => {
       this.props.updateUser(this.state, this.props.user.details.id)
+      this.props.getUser(this.props.user.details.id)
     }
 
   render() {
@@ -85,4 +86,4 @@ function profileState(state) {
     user: state.user,
   }
 }
-export default connect(profileState, { upload, messageShow, messageHide, updateUser })(ProfilePicture)
+export default connect(profileState, { upload, messageShow, messageHide, updateUser, getUser })(ProfilePicture)

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -11,6 +11,7 @@ export const LOGIN_REQUEST = 'AUTH/LOGIN_REQUEST'
 export const LOGIN_RESPONSE = 'AUTH/LOGIN_RESPONSE'
 export const SET_USER = 'AUTH/SET_USER'
 export const LOGOUT = 'AUTH/LOGOUT'
+export const UPDATE_USER = 'AUTH/UPDATE_USER'
 
 // Actions
 
@@ -120,10 +121,10 @@ export function getGenders() {
 // Updating the user info 
 export function updateUser(user, id) {
   return dispatch => {
-    dispatch({
-      type: UPDATE_IMAGE,
-      user
-    })
+    // dispatch({
+    //   type: UPDATE_IMAGE,
+    //   user
+    // })
     return axios.post(routeApi, {
       query: `
       mutation userUpdate($image: String!) {
@@ -135,6 +136,27 @@ export function updateUser(user, id) {
     variables: {
       image: user.imgURL,
     },
+    })
+  }
+}  
+// Get single user
+export function getUser(id) {
+  return dispatch => {
+    axios.post(routeApi, query({
+      operation: 'user',
+      variables: { id },
+      fields: ['name', 'email', 'role', 'image', 'id']
+    }))
+    .then(response => {
+      const user = response.data.data.user
+  
+      dispatch({
+        type: UPDATE_USER,
+        user
+      })
+    })
+    .catch(error => {
+      console.log(error)
     })
   }
 }

--- a/code/web/src/modules/user/api/state.js
+++ b/code/web/src/modules/user/api/state.js
@@ -1,6 +1,6 @@
 // App Imports
 import { isEmpty } from '../../../setup/helpers'
-import { SET_USER, LOGIN_REQUEST, LOGIN_RESPONSE, LOGOUT } from './actions'
+import { SET_USER, LOGIN_REQUEST, LOGIN_RESPONSE, LOGOUT, UPDATE_USER } from './actions'
 
 // Initial State
 export const userInitialState = {
@@ -41,6 +41,12 @@ export default (state = userInitialState, action) => {
         isLoading: false,
         isAuthenticated: false,
         details: null
+      }
+    
+    case UPDATE_USER:
+      return{
+        ...state,
+        details: action.user
       }
 
     default:


### PR DESCRIPTION
#### What's this PR do?
- Fixes error with profile image re-render
- Adds UPDATE_USER action and case to reducer file
#### Where should the reviewer start?
- The bulk of this work happens in `user/api/actions` & `user/api/state`; check out the new action and reducer here. Then head to the ProfilePicture component to see this method getting called in `saveChanges`
#### How should this be manually tested?
- Open app in the browser, visit a user's profile page. Ensure that you can upload an image, that it re-renders, and persists over a page reload/switching pages.
#### Any background context you want to provide?
- After getting the initial profile photo upload setup, we needed a way to update `store` automatically and re-render the image.
#### What are the relevant tickets?
- #32 