### PR TITLE
Fix image and profile data re-rendering

### DIFF
--- a/code/web/src/modules/user/ProfilePicture.js
+++ b/code/web/src/modules/user/ProfilePicture.js
@@ -6,26 +6,24 @@ import { upload, messageShow, messageHide } from '../common/api/actions'
 import { renderIf } from '../../setup/helpers'
 import { routeImage } from '../../setup/routes'
 import { APP_URL, APP_URL_API } from '../../setup/config/env'
-import { updateUser, getUser } from './api/actions'
+import { updateProfileData } from './api/actions'
 
 class ProfilePicture extends Component {
   constructor() {
-    super() 
+    super()
     this.state = {
-      imgURL: '',
-      name: '',
-      email: '',
+      id: '',
+      image: '',
     }
   }
 
   componentDidMount() {
     this.setState({
-      imgURL: this.props.user.details.imgURL || '',
-      name: this.props.user.details.name,
-      email: this.props.user.details.email,
+      image: this.props.user.details.image || '',
+      id: this.props.user.details.id
     })
   }
-  
+
   onUpload = (e) => {
     this.props.messageShow('Uploading file, please wait...')
 
@@ -36,11 +34,12 @@ class ProfilePicture extends Component {
       .then(response => {
         if (response.status === 200) {
           this.props.messageShow('File uploaded successfully.')
-          
+
           this.setState({
-            imgURL: `/images/uploads/${response.data.file}`
+            image: `/images/uploads/${response.data.file}`
           })
           this.saveChanges()
+
         } else {
           this.props.messageShow('Please try again.')
         }
@@ -56,8 +55,7 @@ class ProfilePicture extends Component {
     }
 
     saveChanges = () => {
-      this.props.updateUser(this.state, this.props.user.details.id)
-      this.props.getUser(this.props.user.details.id)
+      this.props.updateProfileData(this.state)
     }
 
   render() {
@@ -84,4 +82,4 @@ function profileState(state) {
     user: state.user,
   }
 }
-export default connect(profileState, { upload, messageShow, messageHide, updateUser, getUser })(ProfilePicture)
+export default connect(profileState, { upload, messageShow, messageHide, updateProfileData })(ProfilePicture)

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -37,33 +37,33 @@ export function login(userCredentials, isLoading = true) {
     return axios.post(routeApi, query({
       operation: 'userLogin',
       variables: userCredentials,
-      fields: ['user {name, email, role, image, id}', 'token']
+      fields: ['user {name, email, role, image, id, streetAddress1, streetAddress2, city, state, zip, description, deliveryDate}', 'token']
     }))
-      .then(response => {
-        let error = ''
+    .then(response => {
+      let error = ''
 
-        if (response.data.errors && response.data.errors.length > 0) {
-          error = response.data.errors[0].message
-        } else if (response.data.data.userLogin.token !== '') {
-          const token = response.data.data.userLogin.token
-          const user = response.data.data.userLogin.user
+      if (response.data.errors && response.data.errors.length > 0) {
+        error = response.data.errors[0].message
+      } else if (response.data.data.userLogin.token !== '') {
+        const token = response.data.data.userLogin.token
+        const user = response.data.data.userLogin.user
 
-          dispatch(setUser(token, user))
+        dispatch(setUser(token, user))
 
-          loginSetUserLocalStorageAndCookie(token, user)
-        }
+        loginSetUserLocalStorageAndCookie(token, user)
+      }
 
-        dispatch({
-          type: LOGIN_RESPONSE,
-          error
-        })
+      dispatch({
+        type: LOGIN_RESPONSE,
+        error
       })
-      .catch(error => {
-        dispatch({
-          type: LOGIN_RESPONSE,
-          error: 'Please try again'
-        })
+    })
+    .catch(error => {
+      dispatch({
+        type: LOGIN_RESPONSE,
+        error: 'Please try again'
       })
+    })
   }
 }
 
@@ -120,52 +120,16 @@ export function getGenders() {
   }
 }
 
-// Updating the user image
-export function updateUser(user, id) {
-  return dispatch => {
-    return axios.post(routeApi, {
-      query: `
-      mutation userUpdate($image: String! ) {
-        userUpdate(id: ${id}, image: $image) {
-          image
-          email
-        }
-      }
-    `,
-    variables: {
-      image: user.imgURL,
-    },
-    })
-  }
-}
-
 // update profile info
-export function updateProfileData(updatedUser) {
+export function updateProfileData(params) {
   return dispatch => {
     return axios.post(routeApi, mutation({
       operation: 'userUpdate',
-      variables: updatedUser,
-      fields: ['id', 'email', 'streetAddress1', 'streetAddress2', 'city', 'state', 'zip', 'description', 'image']
-    })).then(response => {
-      dispatch({
-        type: UPDATE_USER,
-        ...user, updatedUser
-      })
-    })
-  }
-}
-
-
-// Get single user
-export function getUser(id) {
-  return dispatch => {
-    axios.post(routeApi, query({
-      operation: 'user',
-      variables: { id },
-      fields: ['name', 'email', 'role', 'image', 'id']
+      variables: params,
+      fields: ['id', 'name', 'email', 'streetAddress1', 'streetAddress2', 'city', 'state', 'zip', 'description', 'image', 'deliveryDate']
     }))
     .then(response => {
-      const user = response.data.data.user
+      const user = response.data.data.userUpdate
 
       dispatch({
         type: UPDATE_USER,

--- a/code/web/src/modules/user/api/state.js
+++ b/code/web/src/modules/user/api/state.js
@@ -43,7 +43,7 @@ export default (state = userInitialState, action) => {
         isAuthenticated: false,
         details: null
       }
-    
+
     case UPDATE_USER:
       return{
         ...state,

--- a/code/web/src/ui/Form/Form.js
+++ b/code/web/src/ui/Form/Form.js
@@ -22,13 +22,13 @@ class Form extends Component {
       editDeliveryDate: false,
       editShippingAddress: false,
       email: props.user.details.email || '',
-      description: this.description === '' ? props.user.details.description : 'Tell us about yourself!',
+      description: props.user.details.description || 'Tell us about yourself!',
       deliveryDate: props.user.details.deliveryDate || '1st',
-      streetAddress1: this.streetAddress1 === "" ? props.user.details.streetAddress1 : null,
-      streetAddress2: this.streetAddress2 === "" ? props.user.details.streetAddress2 : '',
-      city: this.city === "" ? props.user.details.city : null,
-      state: this.state === ""  ?props.user.details.state : null,
-      zip: this.zip === "" ? props.user.details.zip : null
+      streetAddress1: this.streetAddress1 === "" ? null: props.user.details.streetAddress1,
+      streetAddress2: this.streetAddress2 === "" ? '': props.user.details.streetAddress2,
+      city: this.city === "" ? null: props.user.details.city,
+      state: this.state === "" ? null: props.user.details.state,
+      zip: this.zip === "" ? null: props.user.details.zip
     }
   }
 
@@ -127,7 +127,7 @@ class Form extends Component {
               </div>
             ) : (
               <p style={{ color: grey2, marginBottom: '0', marginRight: '.5em', display: 'inline' }}>
-                {this.state.streetAddress1 === null ? 'Please add ' : this.state.streetAddress1 + " "}
+                {this.state.streetAddress1 === null ? 'Please ' : this.state.streetAddress1 + " "}
                 {this.state.streetAddress2 === null ? 'enter ' : this.state.streetAddress2 + " "}
                 {this.state.city === null ? 'your ' : this.state.city + " "}
                 {this.state.state ===  null ? 'shipping ' : this.state.state + " "}


### PR DESCRIPTION
#### What's this PR do?

Fixes re-render bugs

This PR can also be considered a refactor!

#### Where should the reviewer start?

`actions.js`

#### How should this be manually tested?

- Pull down the branch
- in `api`, run `npm db:reset`
- start the app
- start postico, go to user table
- Log in as user
- Upload photo, then all other information
- *IMPORTANT* click the save button, don't use the return key
- refresh the table view in postico

#### Any background context you want to provide?

After updating the info *DO NOT REFRESH THE PAGE*
Instead: flip to a different tab (subscription, crate) and then back to profile
Log out and log back in

#### What are the relevant tickets?

closes #59 
closes #60 
